### PR TITLE
:ambulance: refactor: 언팔로우 후 다시 팔로우 할 때 관계 생성 기능 수정

### DIFF
--- a/src/main/java/com/sixsense/newsfeed/domain/FollowRelationship.java
+++ b/src/main/java/com/sixsense/newsfeed/domain/FollowRelationship.java
@@ -37,7 +37,11 @@ public class FollowRelationship extends BaseEntity {
         status = Status.ACTIVE;
     }
 
-    // 팔로우 상태 변경 메서드
+    // status active
+    public void active() {
+        status = Status.ACTIVE;
+    }
+    // status inactive
     public void inactive() {
         status = Status.INACTIVE;
     }

--- a/src/main/java/com/sixsense/newsfeed/repository/FollowRelationshipRepository.java
+++ b/src/main/java/com/sixsense/newsfeed/repository/FollowRelationshipRepository.java
@@ -10,9 +10,6 @@ import java.util.Optional;
 
 public interface FollowRelationshipRepository extends JpaRepository<FollowRelationship, Long> {
 
-    // 이미 팔로잉하고 있는지 확인
-    boolean existsByFollowerAndFollowing(User follower, User following);
-
     // 나를 팛로우 하고 있는 친구의 목록
     List<FollowRelationship> findAllByFollowingIdAndStatus(Long friendId, Status active);
 


### PR DESCRIPTION
언팔로우 후 동일한 id를 다시 팔로우 할 때 새로 팔로우 관계가 생성되지 않고
기존에 있는 팔로우 관계를 찾아 ACTIVE 상태로 바뀌도록 수정했습니다. 